### PR TITLE
Redis as a store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 
 gem 'rails', '~> 5.0.2'
 gem 'pg', '~> 0.18'
+gem 'redis-namespace'
 gem 'puma', '~> 3.0'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
+    redis (3.3.3)
+    redis-namespace (1.5.3)
+      redis (~> 3.0, >= 3.0.4)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -159,6 +162,7 @@ DEPENDENCIES
   pg (~> 0.18)
   puma (~> 3.0)
   rails (~> 5.0.2)
+  redis-namespace
   rspec-rails
   sass-rails (~> 5.0)
   tzinfo-data
@@ -166,4 +170,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.13.2
+   1.14.6

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,7 @@ class HomeController < ApplicationController
   end
 
   def record_rate_limit_request
-    Request.create(ip_address: request.remote_ip, requested_at: Time.zone.now)
+    Request.add(request.remote_ip)
   end
 
 end

--- a/app/models/rate_limit.rb
+++ b/app/models/rate_limit.rb
@@ -10,7 +10,7 @@ class RateLimit
   end
 
   def requests
-    @requests ||= Request.requests_for_ip_during_time_period(ip_address, time_period: time_period).limit(maximum_requests)
+    @requests ||= Request.requests_for_ip_during_time_period(ip_address, time_period: time_period)
   end
 
   def request_permitted?
@@ -19,7 +19,7 @@ class RateLimit
 
   def time_until_next_request_permitted
     interval = Time.zone.now - time_period # Gets the period we are limiting for in seconds
-    next_request_at = (requests.last.requested_at + interval)
+    next_request_at = (requests.last + interval)
     next_request_in = (next_request_at - Time.zone.now).to_i
     "Rate limit exceeded, please try again in #{next_request_in} seconds"
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,12 +1,34 @@
-class Request < ActiveRecord::Base
+class Request
 
-  validates :ip_address, :requested_at, presence: true
+  # scope :for_ip_address, -> (requesting_ip) { where(ip_address: requesting_ip)}
+  def self.for_ip_address(requesting_ip)
+    requests = JSON.parse(redis.get(requesting_ip) || [].to_json).map { |requested_at| Time.zone.parse(requested_at) }
+  end
 
-  scope :within_interval, -> (threshold_time) { where("requested_at > ?", threshold_time) }
-  scope :for_ip_address, -> (requesting_ip) { where(ip_address: requesting_ip)}
+  def self.add(requesting_ip, requested_at: Time.zone.now)
+    requests = JSON.parse(redis.get(requesting_ip) || [].to_json)
+    requests << requested_at
+    requests = requests.sort.reverse
+    redis.set(requesting_ip, requests.to_json)
+  end
 
   def self.requests_for_ip_during_time_period(ip_address, time_period: 60.minutes.ago)
-    for_ip_address(ip_address).within_interval(time_period).order('requested_at desc')
+    for_ip_address(ip_address).select { |requested_at| requested_at > time_period }
+  end
+
+  def self.count
+    redis.keys.count
+  end
+
+  private
+
+  def self.redis_connection
+    @redis_connection = Redis.new
+  end
+
+  def self.redis
+    namespace = "requests_#{Rails.env}".to_sym
+    @redis = Redis::Namespace.new(namespace, redis: redis_connection)
   end
 
 end

--- a/spec/models/rate_limit_spec.rb
+++ b/spec/models/rate_limit_spec.rb
@@ -11,8 +11,8 @@ describe RateLimiter do
   context do
     let(:request_ip) { '127.0.0.1' }
     let(:other_ip) { '10.0.0.10' }
-    let!(:previous_requests) { (1..10).each { |number| Request.create(ip_address: request_ip, requested_at: number.minutes.ago)} }
-    let!(:other_requests) { (1..10).each { |number| Request.create(ip_address: other_ip, requested_at: number.minutes.ago)} }
+    let!(:previous_requests) { (1..10).each { |number| Request.add(request_ip, requested_at: number.minutes.ago)} }
+    let!(:other_requests) { (1..10).each { |number| Request.add(other_ip, requested_at: number.minutes.ago)} }
     let(:rate_limiter) { RateLimit.new(ip_address) }
 
     it 'can get the requests for a time period' do

--- a/spec/models/requests_spec.rb
+++ b/spec/models/requests_spec.rb
@@ -2,50 +2,32 @@ require 'rails_helper'
 
 describe Request do
 
-  it 'requires an ip address' do
-    request = Request.new
-    request.requested_at = Time.zone.now
-    expect(request).to_not be_valid
-    request.ip_address = '127.0.0.1'
-    expect(request.save).to eq(true)
-  end
+  let(:request_ip) { '127.0.0.1' }
+  let(:other_ip) { '10.0.0.10' }
+  let!(:previous_requests) { (1..10).each { |number| Request.add(request_ip, requested_at: number.minutes.ago)} }
+  let!(:other_requests) { (1..10).each { |number| Request.add(other_ip, requested_at: number.minutes.ago)} }
 
-  it 'requires the time a request was made' do
-    request = Request.new
-    request.ip_address = '127.0.0.1'
-    expect(request).to_not be_valid
-    request.requested_at = Time.zone.now
-    expect(request.save).to eq(true)
-  end
-
-  context do
-    let(:request_ip) { '127.0.0.1' }
-    let(:other_ip) { '10.0.0.10' }
-    let!(:previous_requests) { (1..10).each { |number| Request.create(ip_address: request_ip, requested_at: number.minutes.ago)} }
-    let!(:other_requests) { (1..10).each { |number| Request.create(ip_address: other_ip, requested_at: number.minutes.ago)} }
-
-    it 'orders the requests by requested at, newest to oldest' do
-      requests = Request.requests_for_ip_during_time_period(request_ip)
-      requests.each_with_index do |request, counter|
-        if counter < (requests.size - 1) # Don't try to compare the last one against something outside the array
-          expect(request.requested_at > requests[counter + 1].requested_at).to eq(true)
-        end
+  it 'orders the requests by requested at, newest to oldest' do
+    requests = Request.requests_for_ip_during_time_period(request_ip)
+    requests.each_with_index do |request, counter|
+      if counter < (requests.size - 1) # Don't try to compare the last one against something outside the array
+        expect(request > requests[counter + 1]).to eq(true)
       end
     end
-
-    it 'can count up requests for over a time period' do
-      expect(Request.within_interval(60.minutes.ago).size).to eq(20)
-    end
-
-    it 'can count up requests for a requesting ip address' do
-      expect(Request.for_ip_address(request_ip).size).to eq(10)
-      expect(Request.for_ip_address(other_ip).size).to eq(10)
-    end
-
-    it 'can count requests for a requesting ip address over a time period' do
-      expect(Request.requests_for_ip_during_time_period(request_ip).size).to eq(10)
-      expect(Request.requests_for_ip_during_time_period(request_ip, time_period: 6.minutes.ago).size).to eq(5)
-    end
-
   end
+
+  it 'can count up requests for over a time period' do
+    expect(Request.requests_for_ip_during_time_period(request_ip, time_period: 9.minutes.ago).size).to eq(8)
+  end
+
+  it 'can count up requests for a requesting ip address' do
+    expect(Request.for_ip_address(request_ip).size).to eq(10)
+    expect(Request.for_ip_address(other_ip).size).to eq(10)
+  end
+
+  it 'can count requests for a requesting ip address over a time period' do
+    expect(Request.requests_for_ip_during_time_period(request_ip).size).to eq(10)
+    expect(Request.requests_for_ip_during_time_period(request_ip, time_period: 6.minutes.ago).size).to eq(5)
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each) do
+    redis_connection = Redis.new
+    namespace = "requests_#{Rails.env}".to_sym
+    redis = Redis::Namespace.new(namespace, redis: redis_connection)
+    keys = redis.keys
+    redis.del(*keys) unless keys.empty?
+    expect(redis.keys.size).to eq(0)
+  end
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -16,7 +16,7 @@ describe "Home Controller" do
 
   context 'hitting the rate limit' do
     let!(:requests) do
-      (1..99).each { |number| Request.create(ip_address: '127.0.0.1', requested_at: number.seconds.ago )}
+      (1..99).each { |number| Request.add('127.0.0.1', requested_at: number.seconds.ago )}
     end
 
     it 'renders a 429 if the rate limit threshold has been hit' do


### PR DESCRIPTION
There could be occasions where we want to use Redis to store our rate limiting information about IP addresses. This is a simple starting point for a possible path for that implementation.